### PR TITLE
Use application id to identify streams.

### DIFF
--- a/src/classify.h
+++ b/src/classify.h
@@ -39,13 +39,10 @@ struct pa_sink_input;
 struct pa_sink_input_new_data;
 struct pa_card;
 
-struct pa_classify_pid_hash {
-    struct pa_classify_pid_hash *next;
-    pid_t                        pid;   /* process id (or parent process id) */
-                                        /* for stream classification */
-    pa_policy_match_object      *pid_match;
-    char                        *group; /* policy group name */
-};
+typedef struct pa_classify_app_id {
+    pa_policy_match_object      *match;
+    char                        *group;
+} pa_classify_app_id;
 
 struct pa_classify_stream_def {
     struct pa_classify_stream_def *next;
@@ -63,7 +60,7 @@ struct pa_classify_stream_def {
 };
 
 struct pa_classify_stream {
-    struct pa_classify_pid_hash   *pid_hash[PA_POLICY_PID_HASH_MAX];
+    pa_hashmap                    *app_id_map;
     struct pa_classify_stream_def *defs;
 };
 
@@ -160,6 +157,11 @@ void  pa_classify_update_stream_route(struct userdata *u, const char *sname);
 void  pa_classify_register_pid(struct userdata *, pid_t, const char *,
                                enum pa_classify_method, const char *, const char *);
 void  pa_classify_unregister_pid(struct userdata *, pid_t, const char *,
+                                 enum pa_classify_method, const char *);
+
+void  pa_classify_register_app_id(struct userdata *, const char *, const char *,
+                               enum pa_classify_method, const char *, const char *);
+void  pa_classify_unregister_app_id(struct userdata *, const char *, const char *,
                                  enum pa_classify_method, const char *);
 
 const char *pa_classify_sink_input(struct userdata *u, struct pa_sink_input *sinp,

--- a/src/client-ext.c
+++ b/src/client-ext.c
@@ -198,6 +198,16 @@ const char *pa_client_ext_arg0(struct pa_client *client)
     return arg0;
 }
 
+#ifndef PA_PROP_POLICY_APPLICATION_ID
+#define PA_PROP_POLICY_APPLICATION_ID "policy.application.id"
+#endif
+
+const char *pa_client_ext_app_id(struct pa_client *client)
+{
+    pa_assert(client);
+
+    return pa_proplist_gets(client->proplist, PA_PROP_POLICY_APPLICATION_ID);
+}
 
 static void handle_client_events(pa_core *c,pa_subscription_event_type_t t,
 				 uint32_t idx, void *userdata)

--- a/src/client-ext.h
+++ b/src/client-ext.h
@@ -25,6 +25,7 @@ uid_t  pa_client_ext_uid(struct pa_client *);
 const char *pa_client_ext_exe(struct pa_client *);
 const char *pa_client_ext_args(struct pa_client *);
 const char *pa_client_ext_arg0(struct pa_client *);
+const char *pa_client_ext_app_id(struct pa_client *);
 
 
 #endif

--- a/src/dbusif.c
+++ b/src/dbusif.c
@@ -519,7 +519,7 @@ static void handle_admin_message(struct userdata *u, DBusMessage *msg)
 static void handle_info_message(struct userdata *u, DBusMessage *msg)
 {
     dbus_uint32_t  txid;
-    dbus_uint32_t  pid;
+    char          *app_id;
     char          *oper;
     char          *group;
     char          *arg;
@@ -532,7 +532,7 @@ static void handle_info_message(struct userdata *u, DBusMessage *msg)
                                     DBUS_TYPE_UINT32, &txid,
                                     DBUS_TYPE_STRING, &oper,
                                     DBUS_TYPE_STRING, &group,
-                                    DBUS_TYPE_UINT32, &pid,
+                                    DBUS_TYPE_STRING, &app_id,
                                     DBUS_TYPE_STRING, &arg,
                                     DBUS_TYPE_STRING, &method_str,
                                     DBUS_TYPE_STRING, &prop,
@@ -572,18 +572,18 @@ static void handle_info_message(struct userdata *u, DBusMessage *msg)
     if (!strcmp(oper, "register")) {
 
         if (pa_policy_group_find(u, group) == NULL) {
-            pa_log_debug("register client (%s|%u) failed: unknown group",
-                         group, pid);
+            pa_log_debug("register client (%s|%s) failed: unknown group",
+                         group, app_id);
         }
         else {
-            pa_log_debug("register client (%s|%u)", group, pid);
-            pa_classify_register_pid(u, (pid_t)pid, prop, method, arg, group);
+            pa_log_debug("register client (%s|%s)", group, app_id);
+            pa_classify_register_app_id(u, app_id, prop, method, arg, group);
             pa_sink_input_ext_rediscover(u);
         }
     }
     else if (!strcmp(oper, "unregister")) {
-        pa_log_debug("unregister client (%s|%u)", group, pid);
-        pa_classify_unregister_pid(u, (pid_t)pid, prop, method, arg);
+        pa_log_debug("unregister client (%s|%s)", group, app_id);
+        pa_classify_unregister_app_id(u, app_id, prop, method, arg);
     }
     else {
         pa_log("invalid operation: '%s'", oper);


### PR DESCRIPTION
Use application id to identify streams instead of pids. Rework classify
to use hashmap instead of pid hash.