### PR TITLE
Follow port availability.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,6 +14,7 @@ module_policy_enforcement_la_SOURCES = \
 			source-output-ext.c \
 			card-ext.c \
 			module-ext.c \
+			port-ext.c \
 			classify.c \
 			policy-group.c \
 			context.c \

--- a/src/classify.c
+++ b/src/classify.c
@@ -1516,6 +1516,50 @@ struct pa_classify_port_entry *pa_classify_get_port_entry(struct pa_classify_dev
     return NULL;
 }
 
+int pa_classify_port_get_device_types(struct userdata *u,
+                                      pa_direction_t direction,
+                                      const char *port_name,
+                                      int flags,
+                                      struct pa_classify_result **p_types)
+{
+    struct pa_classify_port_entry *port;
+    struct pa_classify_result *result = NULL;
+    uint32_t idx;
+    int count = 0;
+
+    pa_assert(u);
+    pa_assert(port_name);
+
+    struct pa_classify_device_def *d = direction == PA_DIRECTION_OUTPUT ? u->classify->sinks->defs : u->classify->sources->defs;
+
+    if (p_types) {
+        *p_types = pa_xnew0(struct pa_classify_result, 1);
+        result = *p_types;
+    }
+
+    for (;  d->type;  d++) {
+        if (!d->data.ports || (flags && !(d->data.flags & flags)))
+            continue;
+
+        PA_IDXSET_FOREACH(port, d->data.ports, idx) {
+            if (pa_streq(port_name, port->port_name)) {
+                if (result) {
+                    if (result->count == 0) {
+                        result->types[result->count++] = d->type;
+                    } else {
+                        size_t newsize = sizeof(*result) + sizeof(result->types[0]) * (result->count + 1);
+                        result = *p_types = pa_xrealloc(result, newsize);
+                        result->types[result->count++] = d->type;
+                    }
+                }
+                count++;
+            }
+        }
+    }
+
+    return count;
+}
+
 /*
  * Local Variables:
  * c-basic-offset: 4

--- a/src/classify.h
+++ b/src/classify.h
@@ -22,9 +22,10 @@
 /* device flags */
 #define PA_POLICY_REFRESH_PORT_ALWAYS (1UL << 3)
 #define PA_POLICY_DELAYED_PORT_CHANGE (1UL << 4)
+#define PA_POLICY_UPDATE_AVAILABLE    (1UL << 5)
 
 /* module flags */
-#define PA_POLICY_MODULE_UNLOAD_IMMEDIATELY (1UL << 5)
+#define PA_POLICY_MODULE_UNLOAD_IMMEDIATELY (1UL << 6)
 
 /* module type */
 #define PA_POLICY_MODULE_FOR_SINK   (0)
@@ -211,6 +212,16 @@ struct pa_classify_port_entry *pa_classify_get_port_entry(struct pa_classify_dev
 
 int pa_classify_update_module(struct userdata *u, uint32_t dir, struct pa_classify_device_data *device);
 void pa_classify_update_modules(struct userdata *u, uint32_t dir, const char *type);
+
+/* Get all device types that contain give port name.
+ * Returns the number of device types containing the port,
+ * If types is not NULL it will be filled with the device types.
+ * Free the types pointer after use. */
+int pa_classify_port_get_device_types(struct userdata *u,
+                                      pa_direction_t direction,
+                                      const char *port_name,
+                                      int flags,
+                                      struct pa_classify_result **p_types);
 
 #endif
 

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -2173,6 +2173,8 @@ static int flags_parse(struct userdata  *u,
             flags |= PA_POLICY_DELAYED_PORT_CHANGE;
         else if (device && !strcmp(flagname, "module_unload_immediately"))
             flags |= PA_POLICY_MODULE_UNLOAD_IMMEDIATELY;
+        else if (device && !strcmp(flagname, "update_available"))
+            flags |= PA_POLICY_UPDATE_AVAILABLE;
 
         else if (stream && !strcmp(flagname, "mute_if_active"))
             flags |= PA_POLICY_LOCAL_MUTE;

--- a/src/dbusif.c
+++ b/src/dbusif.c
@@ -38,6 +38,7 @@
 #define SAILFISH_DBUS_POLICY_IFACE                      "com.sailfish.policy"
 #define SAILFISH_DBUS_POLICY_PATH                       "/com/sailfish/policy"
 #define SAILFISH_DBUS_POLICY_DEVICE_STATE_CHANGED       "deviceStateChanged"
+#define SAILFISH_DBUS_POLICY_DEVICE_STATE_CHANGED_MANY  "deviceStateChangedMany"
 #define SAILFISH_DBUS_CARD_PROFILE_CHANGED              "cardProfileChanged"
 
 #define POLICY_DECISION             "decision"
@@ -298,56 +299,58 @@ void pa_policy_dbusif_done(struct userdata *u)
     }
 }
 
-void pa_policy_dbusif_send_device_state(struct userdata *u, const char *state,
-                                        const struct pa_classify_result *list)
+void pa_policy_dbusif_send_device_state(struct userdata *u, bool is_connected, const struct pa_classify_result *list)
 {
-    const char              *path = POLICY_DBUS_STATE_PATH;
+    int                      success     = 0;
+    DBusConnection          *conn        = pa_dbus_connection_get(u->dbusif->conn);
+    DBusMessage             *msg         = NULL;
+    DBusMessageIter          msg_it;
+    DBusMessageIter          array_it;
+    dbus_int32_t             driver      = is_connected ? 1 : 0;
+    dbus_int32_t             connected   = -1;
+    dbus_uint32_t            serial      = 0;
 
-    struct pa_policy_dbusif *dbusif = u->dbusif;
-    DBusConnection          *conn   = pa_dbus_connection_get(dbusif->conn);
-    DBusMessage             *msg;
-    DBusMessageIter          mit;
-    DBusMessageIter          dit;
-    uint32_t                 i;
-    int                      sts;
+    msg = dbus_message_new_method_call(POLICY_DBUS_PDNAME,
+                                       SAILFISH_DBUS_POLICY_PATH,
+                                       SAILFISH_DBUS_POLICY_IFACE,
+                                       SAILFISH_DBUS_POLICY_DEVICE_STATE_CHANGED_MANY);
 
-    if (!dbusif->regist)
-        return;
-
-    if (!list || list->count == 0)
-        return;
-
-    msg = dbus_message_new_signal(path, dbusif->ifnam, POLICY_DBUS_INFO);
-
-    if (msg == NULL) {
-        pa_log("failed to make new info message");
-        goto fail;
+    if (!msg) {
+        pa_log("Failed to create D-Bus message to set availability");
+        goto done;
     }
 
-    dbus_message_iter_init_append(msg, &mit);
+    dbus_message_iter_init_append(msg, &msg_it);
 
-    if (!dbus_message_iter_append_basic(&mit, DBUS_TYPE_STRING, &state) ||
-        !dbus_message_iter_open_container(&mit, DBUS_TYPE_ARRAY,"s", &dit)){
-        pa_log("failed to build info message");
-        goto fail;
+    if (!dbus_message_iter_open_container(&msg_it, DBUS_TYPE_ARRAY,"(sii)", &array_it)) {
+        pa_log("failed to build device state changed message");
+        goto done;
     }
 
-    for (i = 0; i < list->count; i++) {
-        if (!dbus_message_iter_append_basic(&dit, DBUS_TYPE_STRING, &list->types[i])) {
-            pa_log("failed to build info message");
-            goto fail;
+    for (int i = 0; i < list->count; i++) {
+        DBusMessageIter struct_it;
+        dbus_message_iter_open_container(&array_it, DBUS_TYPE_STRUCT, NULL, &struct_it);
+
+        if (!dbus_message_iter_append_basic(&struct_it, DBUS_TYPE_STRING, &list->types[i]) ||
+            !dbus_message_iter_append_basic(&struct_it, DBUS_TYPE_INT32, &driver) ||
+            !dbus_message_iter_append_basic(&struct_it, DBUS_TYPE_INT32, &connected)) {
+            pa_log("failed to build device state changed message");
+            goto done;
         }
+
+        dbus_message_iter_close_container(&array_it, &struct_it);
+        pa_log_info("Update device state [%d/%d] type %s -> %s",
+                    i + 1, list->count, list->types[i], is_connected ? "connected" : "disconnected");
     }
 
-    dbus_message_iter_close_container(&mit, &dit);
+    dbus_message_iter_close_container(&msg_it, &array_it);
 
-    sts = dbus_connection_send(conn, msg, NULL);
-
-    if (!sts) {
-        pa_log("Can't send info message: out of memory");
+    if (!(success = dbus_connection_send(conn, msg, &serial))) {
+        pa_log("Failed to send message to set device connected states");
+        goto done;
     }
 
- fail:
+ done:
     if (msg)
         dbus_message_unref(msg);
 }

--- a/src/dbusif.c
+++ b/src/dbusif.c
@@ -35,6 +35,10 @@
 #define POLICY_DBUS_PDPATH          "/com/nokia/policy"
 #define POLICY_DBUS_PDNAME          "org.freedesktop.ohm"
 
+#define SAILFISH_DBUS_POLICY_IFACE                      "com.sailfish.policy"
+#define SAILFISH_DBUS_POLICY_PATH                       "/com/sailfish/policy"
+#define SAILFISH_DBUS_POLICY_DEVICE_STATE_CHANGED       "deviceStateChanged"
+
 #define POLICY_DECISION             "decision"
 #define POLICY_STREAM_INFO          "stream_info"
 #define POLICY_ACTIONS              "audio_actions"
@@ -445,6 +449,48 @@ void pa_policy_dbusif_send_media_status(struct userdata *u, const char *media,
 
         dbus_message_unref(msg);
     }
+}
+
+void pa_policy_dbusif_send_port_available_changed(struct userdata *u,
+                                                  const char *type,
+                                                  bool available)
+{
+    int             success     = 0;
+    DBusConnection *conn        = pa_dbus_connection_get(u->dbusif->conn);
+    DBusMessage    *msg         = NULL;
+    dbus_int32_t    driver      = -1;
+    dbus_int32_t    connected   = available ? 1 : 0;
+    dbus_uint32_t   serial      = 0;
+
+    msg = dbus_message_new_method_call(POLICY_DBUS_PDNAME,
+                                       SAILFISH_DBUS_POLICY_PATH,
+                                       SAILFISH_DBUS_POLICY_IFACE,
+                                       SAILFISH_DBUS_POLICY_DEVICE_STATE_CHANGED);
+
+    if (!msg) {
+        pa_log("Failed to create D-Bus message to set availability");
+        goto done;
+    }
+
+    if (!(success = dbus_message_append_args(msg,
+                                             DBUS_TYPE_STRING, &type,
+                                             DBUS_TYPE_INT32, &driver,
+                                             DBUS_TYPE_INT32, &connected,
+                                             DBUS_TYPE_INVALID))) {
+        pa_log("Failed to build D-Bus message to set availability");
+        goto done;
+    }
+
+    if (!(success = dbus_connection_send(conn, msg, &serial))) {
+        pa_log("Failed to send message to set availability");
+        goto done;
+    }
+
+ done:
+    if (msg)
+        dbus_message_unref(msg);
+    if (success)
+        pa_log_info("Update port for %s -> %s", type, available ? "available" : "unavailable");
 }
 
 static DBusHandlerResult filter(DBusConnection *conn, DBusMessage *msg,

--- a/src/dbusif.c
+++ b/src/dbusif.c
@@ -38,6 +38,7 @@
 #define SAILFISH_DBUS_POLICY_IFACE                      "com.sailfish.policy"
 #define SAILFISH_DBUS_POLICY_PATH                       "/com/sailfish/policy"
 #define SAILFISH_DBUS_POLICY_DEVICE_STATE_CHANGED       "deviceStateChanged"
+#define SAILFISH_DBUS_CARD_PROFILE_CHANGED              "cardProfileChanged"
 
 #define POLICY_DECISION             "decision"
 #define POLICY_STREAM_INFO          "stream_info"
@@ -57,10 +58,6 @@
 #define POLICY_DBUS_MEDIA_PATH      POLICY_DBUS_PDPATH "/" POLICY_DBUS_INFO
 #define POLICY_DBUS_STATE_ACT       "active"
 #define POLICY_DBUS_STATE_INACT     "inactive"
-
-#define POLICY_DBUS_CARD            "card_info"
-#define POLICY_DBUS_CARD_PATH       POLICY_DBUS_PDPATH "/" POLICY_DBUS_CARD
-#define POLICY_DBUS_CARD_PROFILE    "profile_changed"
 
 
 #define STRUCT_OFFSET(s,m) ((char *)&(((s *)0)->m) - (char *)0)
@@ -358,16 +355,11 @@ void pa_policy_dbusif_send_device_state(struct userdata *u, const char *state,
 void pa_policy_dbusif_send_card_profile_changed(struct userdata *u, const struct pa_classify_result *list,
                                                 const char *profile)
 {
-    const char              *path = POLICY_DBUS_CARD_PATH;
-
     struct pa_policy_dbusif *dbusif = u->dbusif;
     DBusConnection          *conn   = pa_dbus_connection_get(dbusif->conn);
-    const char              *event  = POLICY_DBUS_CARD_PROFILE;
     DBusMessage             *msg    = NULL;
-    DBusMessageIter          mit;
-    DBusMessageIter          dit;
     uint32_t                 i;
-    int                      sts;
+    int                      success;
 
     if (!dbusif->regist)
         return;
@@ -378,37 +370,36 @@ void pa_policy_dbusif_send_card_profile_changed(struct userdata *u, const struct
     if (!profile)
         return;
 
-    msg = dbus_message_new_signal(path, dbusif->ifnam, POLICY_DBUS_CARD);
-
-    if (msg == NULL) {
-        pa_log("failed to create new " POLICY_DBUS_CARD " signal");
-        goto done;
-    }
-
-    dbus_message_iter_init_append(msg, &mit);
-
-    if (!dbus_message_iter_append_basic(&mit, DBUS_TYPE_STRING, &event) ||
-        !dbus_message_iter_append_basic(&mit, DBUS_TYPE_STRING, &profile) ||
-        !dbus_message_iter_open_container(&mit, DBUS_TYPE_ARRAY,"s", &dit)) {
-        pa_log("failed to build " POLICY_DBUS_CARD "/" POLICY_DBUS_CARD_PROFILE " signal");
-        goto done;
-    }
-
     for (i = 0; i < list->count; i++) {
-        if (!dbus_message_iter_append_basic(&dit, DBUS_TYPE_STRING, &list->types[i])) {
-            pa_log("failed to build " POLICY_DBUS_CARD "/" POLICY_DBUS_CARD_PROFILE " message");
-            goto done;
+        msg = dbus_message_new_method_call(POLICY_DBUS_PDNAME,
+                                           SAILFISH_DBUS_POLICY_PATH,
+                                           SAILFISH_DBUS_POLICY_IFACE,
+                                           SAILFISH_DBUS_CARD_PROFILE_CHANGED);
+
+        if (msg == NULL) {
+            pa_log("failed to create new " SAILFISH_DBUS_CARD_PROFILE_CHANGED " message");
+            break;
+        }
+
+        if (!(success = dbus_message_append_args(msg,
+                                                 DBUS_TYPE_STRING, &profile,
+                                                 DBUS_TYPE_STRING, &list->types[i],
+                                                 DBUS_TYPE_INVALID))) {
+            pa_log("Failed to build D-Bus " SAILFISH_DBUS_CARD_PROFILE_CHANGED " message");
+            break;
+        }
+
+        success = dbus_connection_send(conn, msg, NULL);
+
+        dbus_message_unref(msg);
+        msg = NULL;
+
+        if (!success) {
+            pa_log("Can't send " SAILFISH_DBUS_CARD_PROFILE_CHANGED " message");
+            break;
         }
     }
 
-    dbus_message_iter_close_container(&mit, &dit);
-
-    sts = dbus_connection_send(conn, msg, NULL);
-
-    if (!sts)
-        pa_log("Can't send " POLICY_DBUS_CARD " message: out of memory");
-
- done:
     if (msg)
         dbus_message_unref(msg);
 }

--- a/src/dbusif.h
+++ b/src/dbusif.h
@@ -10,7 +10,7 @@ struct pa_policy_dbusif *pa_policy_dbusif_init(struct userdata *, const char *,
                                                const char *, const char *,
                                                const char *, bool);
 void pa_policy_dbusif_done(struct userdata *);
-void pa_policy_dbusif_send_device_state(struct userdata *u, const char *state,
+void pa_policy_dbusif_send_device_state(struct userdata *u, bool is_connected,
                                         const struct pa_classify_result *list);
 void pa_policy_dbusif_send_media_status(struct userdata *, const char *,
                                         const char *, int);

--- a/src/dbusif.h
+++ b/src/dbusif.h
@@ -18,6 +18,9 @@ void pa_policy_dbusif_send_media_status(struct userdata *, const char *,
 void pa_policy_dbusif_send_card_profile_changed(struct userdata *u,
                                                 const struct pa_classify_result *list,
                                                 const char *profile);
+void pa_policy_dbusif_send_port_available_changed(struct userdata *u,
+                                                  const char *type,
+                                                  bool available);
 
 #endif
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,6 +12,7 @@ module_policy_enforcement_sources = [
   'module-policy-enforcement.c',
   'policy-group.c',
   'policy.c',
+  'port-ext.c',
   'sink-ext.c',
   'sink-input-ext.c',
   'source-ext.c',

--- a/src/module-policy-enforcement.c
+++ b/src/module-policy-enforcement.c
@@ -41,6 +41,7 @@
 #include "sink-input-ext.h"
 #include "source-output-ext.h"
 #include "card-ext.h"
+#include "port-ext.h"
 #include "module-ext.h"
 #include "dbusif.h"
 #include "variable.h"
@@ -144,13 +145,14 @@ int pa__init(pa_module *m) {
     u->dbusif   = pa_policy_dbusif_init(u, ifnam, mypath, pdpath, pdnam, route_sources_first);
     u->vars     = pa_policy_var_init();
     u->sinkext  = pa_sink_ext_new();
+    u->portext  = pa_port_ext_subscription(u);
     u->shared   = pa_shared_data_get(u->core);
 
     if (u->scl == NULL      || u->ssnk == NULL     || u->ssrc == NULL ||
         u->ssi == NULL      || u->sso == NULL      || u->scrd == NULL ||
         u->smod == NULL     || u->groups == NULL   || u->nullsink == NULL ||
         u->classify == NULL || u->context == NULL  || u->dbusif == NULL ||
-        u->shared == NULL)
+        u->portext == NULL  || u->shared == NULL)
         goto fail;
 
     pa_policy_groupset_update_default_sink(u, PA_IDXSET_INVALID);
@@ -171,6 +173,7 @@ int pa__init(pa_module *m) {
     pa_sink_input_ext_discover(u);
     pa_source_output_ext_discover(u);
     pa_card_ext_discover(u);
+    pa_port_ext_discover(u);
     pa_module_ext_discover(u);
     /* variables are not used after initialization */
     pa_policy_var_done(u->vars);
@@ -208,6 +211,7 @@ void pa__done(pa_module *m) {
     pa_sink_input_ext_subscription_free(u->ssi);
     pa_source_output_ext_subscription_free(u->sso);
     pa_card_ext_subscription_free(u->scrd);
+    pa_port_ext_subscription_free(u->portext);
     pa_module_ext_subscription_free(u->smod);
 
     pa_policy_groupset_free(u->groups);

--- a/src/policy.c
+++ b/src/policy.c
@@ -14,10 +14,10 @@
 #include "classify.h"
 #include "log.h"
 
-void pa_policy_send_device_state(struct userdata *u, const char *state,
+void pa_policy_send_device_state(struct userdata *u, bool is_connected,
                                  const struct pa_classify_result *list)
 {
-    pa_policy_dbusif_send_device_state(u, state, list);
+    pa_policy_dbusif_send_device_state(u, is_connected, list);
 }
 
 void pa_policy_send_card_state(struct userdata *u, const struct pa_classify_result *list,

--- a/src/policy.c
+++ b/src/policy.c
@@ -86,3 +86,13 @@ void pa_policy_send_device_state_full(struct userdata *u)
         pa_xfree(r);
     }
 }
+
+void pa_policy_send_port_available_changed(struct userdata *u,
+                                           const char *type,
+                                           bool available)
+{
+    pa_assert(u);
+    pa_assert(type);
+
+    pa_policy_dbusif_send_port_available_changed(u, type, available);
+}

--- a/src/policy.h
+++ b/src/policy.h
@@ -12,5 +12,8 @@ void pa_policy_send_device_state(struct userdata *u, const char *state,
 void pa_policy_send_device_state_full(struct userdata *u);
 void pa_policy_send_card_state(struct userdata *u, const struct pa_classify_result *list,
                                const char *profile);
+void pa_policy_send_port_available_changed(struct userdata *u,
+                                           const char *type,
+                                           bool available);
 
 #endif

--- a/src/policy.h
+++ b/src/policy.h
@@ -4,10 +4,10 @@
 #include "userdata.h"
 #include "classify.h"
 
-#define PA_POLICY_CONNECTED                "1"
-#define PA_POLICY_DISCONNECTED             "0"
+#define PA_POLICY_CONNECTED                (true)
+#define PA_POLICY_DISCONNECTED             (false)
 
-void pa_policy_send_device_state(struct userdata *u, const char *state,
+void pa_policy_send_device_state(struct userdata *u, bool is_connected,
                                  const struct pa_classify_result *list);
 void pa_policy_send_device_state_full(struct userdata *u);
 void pa_policy_send_card_state(struct userdata *u, const struct pa_classify_result *list,

--- a/src/port-ext.c
+++ b/src/port-ext.c
@@ -1,0 +1,99 @@
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <pulse/def.h>
+#include <pulse/rtclock.h>
+#include <pulse/timeval.h>
+
+#include <pulsecore/core-util.h>
+#include <pulsecore/device-port.h>
+
+#include "classify.h"
+#include "policy.h"
+#include "port-ext.h"
+
+static pa_hook_result_t available_changed(void *hook_data, void *call_data,
+                                          void *slot_data);
+static void handle_available_changed(struct userdata *u, pa_device_port *p);
+
+struct pa_port_evsubscr *pa_port_ext_subscription(struct userdata *u)
+{
+    pa_core                 *core;
+    pa_hook                 *hooks;
+    struct pa_port_evsubscr *subscr;
+
+    pa_assert(u);
+    pa_assert_se((core = u->core));
+
+    hooks = core->hooks;
+
+    subscr = pa_xnew0(struct pa_port_evsubscr, 1);
+
+    subscr->available = pa_hook_connect(hooks + PA_CORE_HOOK_PORT_AVAILABLE_CHANGED,
+                                        PA_HOOK_LATE, available_changed, u);
+
+    return subscr;
+}
+
+void pa_port_ext_subscription_free(struct pa_port_evsubscr *subscr)
+{
+    if (!subscr)
+        return;
+
+    pa_hook_slot_free(subscr->available);
+    pa_xfree(subscr);
+}
+
+void pa_port_ext_discover(struct userdata *u)
+{
+    pa_assert(u);
+    pa_assert(u->portext);
+
+    pa_card *card;
+    uint32_t idx;
+
+    PA_IDXSET_FOREACH(card, u->core->cards, idx) {
+        pa_device_port *device_port;
+        void *state;
+
+        PA_HASHMAP_FOREACH(device_port, card->ports, state) {
+            handle_available_changed(u, device_port);
+        }
+    }
+}
+
+static pa_hook_result_t available_changed(void *hook_data, void *call_data,
+                                          void *slot_data)
+{
+    struct pa_device_port *port = call_data;
+    struct userdata *u          = slot_data;
+
+    handle_available_changed(u, port);
+
+    return PA_HOOK_OK;
+}
+
+static void handle_available_changed(struct userdata *u, pa_device_port *p)
+{
+    struct pa_classify_result *result = NULL;
+    pa_classify_port_get_device_types(u, p->direction, p->name, PA_POLICY_UPDATE_AVAILABLE, &result);
+
+    for (int i = 0; i < result->count; i++)
+        pa_policy_send_port_available_changed(u, result->types[i], p->available == PA_AVAILABLE_YES);
+
+    pa_xfree(result);
+}
+
+/*
+ * Local Variables:
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ *
+ */

--- a/src/port-ext.h
+++ b/src/port-ext.h
@@ -1,0 +1,14 @@
+#ifndef fooportextfoo
+#define fooportextfoo
+
+#include "userdata.h"
+
+struct pa_port_evsubscr {
+    pa_hook_slot    *available;
+};
+
+struct pa_port_evsubscr *pa_port_ext_subscription(struct userdata *u);
+void  pa_port_ext_subscription_free(struct pa_port_evsubscr *subscr);
+void  pa_port_ext_discover(struct userdata *u);
+
+#endif

--- a/src/userdata.h
+++ b/src/userdata.h
@@ -30,6 +30,7 @@ struct pa_policy_context;
 struct pa_policy_dbusif;
 struct pa_policy_variable;
 struct pa_sink_ext_data;
+struct pa_port_ext;
 
 struct userdata {
     pa_core                   *core;
@@ -51,6 +52,7 @@ struct userdata {
     struct pa_policy_dbusif   *dbusif;
     struct pa_policy_variable *vars;
     struct pa_sink_ext_data   *sinkext;
+    struct pa_port_evsubscr   *portext;
     pa_shared_data            *shared;   /* for forwarding context etc properties */
 };
 


### PR DESCRIPTION
Follow port availability and if set in device flags forward the changes to policy framework.

Also change two other signals that were communicating with ohm accessories plugin to be method calls to the new dbus-method plugin.